### PR TITLE
Create own jikan wrapper

### DIFF
--- a/PaperMalKing/Data/EntityType.cs
+++ b/PaperMalKing/Data/EntityType.cs
@@ -1,0 +1,9 @@
+﻿namespace PaperMalKing.Data
+{
+	public enum EntityType
+	{
+
+		Anime = 0,
+		Manga = 1
+	}
+}

--- a/PaperMalKing/Jikan/Data/BaseJikanRequest.cs
+++ b/PaperMalKing/Jikan/Data/BaseJikanRequest.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+
+namespace PaperMalKing.Jikan.Data
+{
+	/// <summary>
+	/// Base model class for each Jikan request model, containing information about cache.
+	/// </summary>
+	public class BaseJikanRequest
+	{
+		/// <summary>
+		/// Hash of the request.
+		/// </summary>
+		[JsonProperty(PropertyName = "request_hash")]
+		public string RequestHash { get; set; }
+
+		/// <summary>
+		/// Is request cached.
+		/// </summary>
+		[JsonProperty(PropertyName = "request_cached")]
+		public bool RequestCached { get; set; }
+
+		/// <summary>
+		/// Time till cache expiration (in seconds).
+		/// </summary>
+		[JsonProperty(PropertyName = "request_cache_expiry")]
+		public int RequestCacheExpiry { get; set; }
+	}
+}

--- a/PaperMalKing/Jikan/Data/EndpointCategories.cs
+++ b/PaperMalKing/Jikan/Data/EndpointCategories.cs
@@ -1,0 +1,85 @@
+﻿namespace PaperMalKing.Jikan.Data
+{
+	sealed class EndpointCategories
+	{
+		/// <summary>
+		/// Anime endpoint.
+		/// </summary>
+		public const string Anime = "anime";
+
+		/// <summary>
+		/// Manga endpoint.
+		/// </summary>
+		public const string Manga = "manga";
+
+		/// <summary>
+		/// Character endpoint.
+		/// </summary>
+		public const string Character = "character";
+
+		/// <summary>
+		/// Characters endpoint.
+		/// </summary>
+		public const string Characters = "characters";
+
+		/// <summary>
+		/// People endpoint.
+		/// </summary>
+		public const string Person = "person";
+
+		/// <summary>
+		/// Alternative people endpoint.
+		/// </summary>
+		public const string People = "people";
+
+		/// <summary>
+		/// Season endpoint.
+		/// </summary>
+		public const string Season = "season";
+
+		/// <summary>
+		/// Schedule endpoint.
+		/// </summary>
+		public const string Schedule = "schedule";
+
+		/// <summary>
+		/// Top list endpoint.
+		/// </summary>
+		public const string TopList = "top";
+
+		/// <summary>
+		/// Genre endpoint.
+		/// </summary>
+		public const string Genre = "genre";
+
+		/// <summary>
+		/// Producer endpoint.
+		/// </summary>
+		public const string Producer = "producer";
+
+		/// <summary>
+		/// Magazine endpoint.
+		/// </summary>
+		public const string Magazine = "magazine";
+
+		/// <summary>
+		/// User endpoint.
+		/// </summary>
+		public const string User = "user";
+
+		/// <summary>
+		/// Club endpoint.
+		/// </summary>
+		public const string Club = "club";
+
+		/// <summary>
+		/// Search endpoint.
+		/// </summary>
+		public const string Search = "search";
+
+		/// <summary>
+		/// Metadata endpoint.
+		/// </summary>
+		public const string Meta = "meta";
+	}
+}

--- a/PaperMalKing/Jikan/Data/Interfaces/IListEntry.cs
+++ b/PaperMalKing/Jikan/Data/Interfaces/IListEntry.cs
@@ -1,0 +1,13 @@
+﻿namespace PaperMalKing.Jikan.Data.Interfaces
+{
+	public interface IListEntry : IMalEntity
+	{
+		int? CompletedSubEntries { get; set; }
+
+		int? TotalSubEntries { get; set; }
+
+		int Score { get; set; }
+
+		StatusType UsersStatus { get; set; }
+	}
+}

--- a/PaperMalKing/Jikan/Data/Interfaces/IMalEntity.cs
+++ b/PaperMalKing/Jikan/Data/Interfaces/IMalEntity.cs
@@ -1,0 +1,30 @@
+﻿namespace PaperMalKing.Jikan.Data.Interfaces
+{
+	public interface IMalEntity
+	{
+		/// <summary>
+		/// ID associated with MyAnimeList.
+		/// </summary>
+		long MalId { get; set; }
+
+		/// <summary>
+		/// Title of the entry.
+		/// </summary>
+		string Title { get; set; }
+
+		/// <summary>
+		/// Entry's image URL
+		/// </summary>
+		string ImageUrl { get; set; }
+
+		/// <summary>
+		/// Entry's URL
+		/// </summary>
+		string Url { get; set; }
+
+		/// <summary>
+		/// Entry type
+		/// </summary>
+		string Type { get; set; }
+	}
+}

--- a/PaperMalKing/Jikan/Data/Models/Anime.cs
+++ b/PaperMalKing/Jikan/Data/Models/Anime.cs
@@ -1,0 +1,30 @@
+﻿using Newtonsoft.Json;
+using PaperMalKing.Jikan.Data.Interfaces;
+
+namespace PaperMalKing.Jikan.Data.Models
+{
+	public sealed class Anime : BaseJikanRequest, IMalEntity
+	{
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "mal_id")]
+		public long MalId { get; set; }
+
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "title")]
+		public string Title { get; set; }
+
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "image_url")]
+		public string ImageUrl { get; set; }
+
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "url")]
+		public string Url { get; set; }
+
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "type")]
+		public string Type { get; set; }
+
+		public static IMalEntity ToIMalEntity(Anime a) => a as IMalEntity;
+	}
+}

--- a/PaperMalKing/Jikan/Data/Models/AnimeListEntry.cs
+++ b/PaperMalKing/Jikan/Data/Models/AnimeListEntry.cs
@@ -1,0 +1,44 @@
+﻿using Newtonsoft.Json;
+using PaperMalKing.Jikan.Data.Interfaces;
+
+namespace PaperMalKing.Jikan.Data.Models
+{
+	public sealed class AnimeListEntry : IListEntry
+	{
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "mal_id")]
+		public long MalId { get; set; }
+
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "title")]
+		public string Title { get; set; }
+
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "image_url")]
+		public string ImageUrl { get; set; }
+
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "url")]
+		public string Url { get; set; }
+
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "type")]
+		public string Type { get; set; }
+
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "watched_episodes")]
+		public int? CompletedSubEntries { get; set; }
+
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "total_episodes")]
+		public int? TotalSubEntries { get; set; }
+
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "score")]
+		public int Score { get; set; }
+
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "watching_status")]
+		public StatusType UsersStatus { get; set; }
+	}
+}

--- a/PaperMalKing/Jikan/Data/Models/Manga.cs
+++ b/PaperMalKing/Jikan/Data/Models/Manga.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+using PaperMalKing.Jikan.Data.Interfaces;
+
+namespace PaperMalKing.Jikan.Data.Models
+{
+	public sealed class Manga : BaseJikanRequest, IMalEntity
+	{
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "mal_id")]
+		public long MalId { get; set; }
+
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "title")]
+		public string Title { get; set; }
+
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "image_url")]
+		public string ImageUrl { get; set; }
+
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "url")]
+		public string Url { get; set; }
+
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "type")]
+		public string Type { get; set; }
+	}
+}

--- a/PaperMalKing/Jikan/Data/Models/MangaListEntry.cs
+++ b/PaperMalKing/Jikan/Data/Models/MangaListEntry.cs
@@ -1,0 +1,44 @@
+﻿using Newtonsoft.Json;
+using PaperMalKing.Jikan.Data.Interfaces;
+
+namespace PaperMalKing.Jikan.Data.Models
+{
+	public sealed class MangaListEntry : IListEntry
+	{
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "mal_id")]
+		public long MalId { get; set; }
+
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "title")]
+		public string Title { get; set; }
+
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "image_url")]
+		public string ImageUrl { get; set; }
+
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "url")]
+		public string Url { get; set; }
+
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "type")]
+		public string Type { get; set; }
+
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "read_chapters")]
+		public int? CompletedSubEntries { get; set; }
+
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "total_chapters")]
+		public int? TotalSubEntries { get; set; }
+
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "score")]
+		public int Score { get; set; }
+
+		/// <inheritdoc />
+		[JsonProperty(PropertyName = "reading_status")]
+		public StatusType UsersStatus { get; set; }
+	}
+}

--- a/PaperMalKing/Jikan/Data/Models/UserAnimeList.cs
+++ b/PaperMalKing/Jikan/Data/Models/UserAnimeList.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace PaperMalKing.Jikan.Data.Models
+{
+	/// <summary>
+	/// User's anime list model class.
+	/// </summary>
+	public sealed class UserAnimeList :BaseJikanRequest
+	{
+		/// <summary>
+		/// Collection of user's anime on their anime list.
+		/// </summary>
+		[JsonProperty(PropertyName = "anime")]
+		public ICollection<AnimeListEntry> Anime { get; set; }
+	}
+}

--- a/PaperMalKing/Jikan/Data/Models/UserMangaList.cs
+++ b/PaperMalKing/Jikan/Data/Models/UserMangaList.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace PaperMalKing.Jikan.Data.Models
+{
+	/// <summary>
+	/// User's manga list model class.
+	/// </summary>
+	public sealed class UserMangaList : BaseJikanRequest 
+	{
+		/// <summary>
+		/// Collection of user's manga on their manga list.
+		/// </summary>
+		[JsonProperty(PropertyName = "manga")]
+		public ICollection<MangaListEntry> Manga { get; set; }
+	}
+}

--- a/PaperMalKing/Jikan/Data/Models/UserProfile.cs
+++ b/PaperMalKing/Jikan/Data/Models/UserProfile.cs
@@ -1,0 +1,34 @@
+﻿using Newtonsoft.Json;
+
+namespace PaperMalKing.Jikan.Data.Models
+{
+	/// <summary>
+	/// User's profile model class.
+	/// </summary>
+	public sealed class UserProfile: BaseJikanRequest
+	{
+		/// <summary>
+		/// Username.
+		/// </summary>
+		[JsonProperty(PropertyName = "username")]
+		public string Username { get; set; }
+
+		/// <summary>
+		/// User's image URL
+		/// </summary>
+		[JsonProperty(PropertyName = "image_url")]
+		public string ImageUrl { get; set; }
+
+		/// <summary>
+		/// User's URL
+		/// </summary>
+		[JsonProperty(PropertyName = "url")]
+		public string Url { get; set; }
+
+		/// <summary>
+		/// User's id.
+		/// </summary>
+		[JsonProperty(PropertyName = "user_id")]
+		public long UserId { get; set; }
+	}
+}

--- a/PaperMalKing/Jikan/Data/StatusType.cs
+++ b/PaperMalKing/Jikan/Data/StatusType.cs
@@ -1,0 +1,62 @@
+﻿namespace PaperMalKing.Jikan.Data
+{
+	public enum StatusType
+	{
+		All = 0,
+
+		/// <summary>
+		/// Reading / Watching
+		/// </summary>
+		InProgress = 1,
+
+		Completed = 2,
+
+		OnHold = 3,
+
+		Dropped = 4,
+
+		/// <summary>
+		/// Plan to read / Plan to watch
+		/// </summary>
+		PlanToCheck = 6,
+
+		Undefined = 7
+	}
+
+	public static class StatusExtension
+	{
+		public static string GetMangaEndpoint(this StatusType status)
+		{
+			if (status == StatusType.All)
+				return "all";
+			if (status == StatusType.InProgress)
+				return "reading";
+			if (status == StatusType.Completed)
+				return "completed";
+			if (status == StatusType.OnHold)
+				return "onhold";
+			if (status == StatusType.Dropped)
+				return "dropped";
+			if (status == StatusType.PlanToCheck)
+				return "plantoread";
+			return "";
+		}
+
+		public static string GetAnimeEndpoint(this StatusType status)
+		{
+			if (status == StatusType.All)
+				return "all";
+			if (status == StatusType.InProgress)
+				return "watching";
+			if (status == StatusType.Completed)
+				return "completed";
+			if (status == StatusType.OnHold)
+				return "onhold";
+			if (status == StatusType.Dropped)
+				return "dropped";
+			if (status == StatusType.PlanToCheck)
+				return "plantowatch";
+			return "";
+		}
+	}
+}

--- a/PaperMalKing/Jikan/Helpers/HttpProvider.cs
+++ b/PaperMalKing/Jikan/Helpers/HttpProvider.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+namespace PaperMalKing.Jikan.Helpers
+{
+	/// <summary>
+	/// Provider class for static HttpClient.
+	/// </summary>
+	public static class HttpProvider
+	{
+		/// <summary>
+		/// Endpoint for not SSL encrypted requests.
+		/// </summary>
+		public const string httpEndpoint = "http://api.jikan.moe/v3/";
+
+		/// <summary>
+		/// Endpoint for SSL encrypted requests.
+		/// </summary>
+		public const string httpsEndpoint = "https://api.jikan.moe/v3/";
+
+		/// <summary>
+		/// Constructor.
+		/// </summary>
+		static HttpProvider()
+		{
+		}
+
+		/// <summary>
+		/// Get static HttpClient. Using default Jikan REST endpoint.
+		/// </summary>
+		/// <param name="useHttps">Define if request should be send to SSL encrypted endpoint.</param>
+		/// <returns>Static HttpClient.</returns>
+		public static HttpClient GetHttpClient(bool useHttps)
+		{
+			var endpoint = useHttps ? httpsEndpoint : httpEndpoint;
+			var Client = new HttpClient
+			{
+				BaseAddress = new Uri(endpoint)
+			};
+			Client.DefaultRequestHeaders.Accept.Clear();
+			Client.DefaultRequestHeaders.Accept.Add(
+				new MediaTypeWithQualityHeaderValue("application/json"));
+
+			return Client;
+		}
+
+		/// <summary>
+		/// Get static HttpClient. Using custom, user defined Jikan REST endpoint.
+		/// </summary>
+		/// <param name="endpoint">Endpoint of the REST API.</param>
+		/// <returns>Static HttpClient.</returns>
+		public static HttpClient GetHttpClient(Uri endpoint)
+		{
+			var Client = new HttpClient
+			{
+				BaseAddress = endpoint
+			};
+			Client.DefaultRequestHeaders.Accept.Clear();
+			Client.DefaultRequestHeaders.Accept.Add(
+				new MediaTypeWithQualityHeaderValue("application/json"));
+
+			return Client;
+		}
+	}
+}

--- a/PaperMalKing/Jikan/JikanClient.cs
+++ b/PaperMalKing/Jikan/JikanClient.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using PaperMalKing.Jikan.Data;
+using PaperMalKing.Jikan.Data.Models;
+using PaperMalKing.Jikan.Helpers;
+
+namespace PaperMalKing.Jikan
+{
+	public sealed class JikanClient
+	{
+		private readonly HttpClient _httpClient;
+
+		private readonly bool _suppressExceptions;
+
+		/// <summary>
+		/// Constructor.
+		/// </summary>
+		public JikanClient()
+		{
+			this._suppressExceptions = true;
+			this._httpClient = HttpProvider.GetHttpClient(true);
+		}
+
+		/// <summary>
+		/// Constructor.
+		/// </summary>
+		/// <param name="useHttps">Should client send SSL encrypted requests.</param>
+		/// <param name="suppressExceptions">Should exception be thrown in case of failed request. If true, failed request return null.</param>
+		public JikanClient(bool useHttps, bool suppressExceptions = true)
+		{
+			this._suppressExceptions = suppressExceptions;
+			this._httpClient = HttpProvider.GetHttpClient(useHttps);
+		}
+
+		/// <summary>
+		/// Constructor.
+		/// </summary>
+		/// <param name="endpointUrl">Endpoint of the REST API.</param>
+		/// <param name="suppressExceptions">Should exception be thrown in case of failed request. If true, failed request return null.</param>
+		public JikanClient(string endpointUrl, bool suppressExceptions = true)
+		{
+			this._suppressExceptions = suppressExceptions;
+			this._httpClient = HttpProvider.GetHttpClient(new Uri(endpointUrl));
+		}
+
+		/// <summary>
+		/// Constructor.
+		/// </summary>
+		/// <param name="endpointUrl">Endpoint of the REST API.</param>
+		/// <param name="suppressExceptions">Should exception be thrown in case of failed request. If true, failed request return null.</param>
+		public JikanClient(Uri endpointUrl, bool suppressExceptions = true)
+		{
+			this._suppressExceptions = suppressExceptions;
+			this._httpClient = HttpProvider.GetHttpClient(endpointUrl);
+		}
+
+		private async Task<T> ExecuteGetRequestAsync<T>(string[] args) where T : BaseJikanRequest
+		{
+			T returnedObject = null;
+			var requestUrl = string.Join("/", args);
+			try
+			{
+				using (HttpResponseMessage response = await this._httpClient.GetAsync(requestUrl))
+				{
+					if (response.IsSuccessStatusCode)
+					{
+						string json = await response.Content.ReadAsStringAsync();
+
+						returnedObject = JsonConvert.DeserializeObject<T>(json);
+					}
+					else if (!this._suppressExceptions)
+					{
+						throw new Exception($"Status code: '{response.StatusCode}'. Message: '{response.Content}'");
+					}
+				}
+			}
+			catch (JsonSerializationException ex)
+			{
+				if (!this._suppressExceptions)
+				{
+					throw new Exception("Serialization failed" + ex.Message);
+				}
+			}
+			return returnedObject;
+		}
+
+		/// <summary>
+		/// Returns information about user's profile with given username.
+		/// </summary>
+		/// <param name="username">Username.</param>
+		/// <returns>Information about user's profile with given username.</returns>
+		public Task<UserProfile> GetUserProfileAsync(string username)
+		{
+			var endpointParts = new[] {EndpointCategories.User, username, "profile"};
+
+			return this.ExecuteGetRequestAsync<UserProfile>(endpointParts);
+		}
+
+		/// <summary>
+		/// Return anime with given MAL id.
+		/// </summary>
+		/// <param name="id">MAL id of anime.</param>
+		/// <returns>Anime with given MAL id.</returns>
+		public Task<Anime> GetAnimeAsync(long id)
+		{
+			var endpointParts = new[] { EndpointCategories.Anime, id.ToString() };
+			return this.ExecuteGetRequestAsync<Anime>(endpointParts);
+		}
+
+		/// <summary>
+		/// Returns entries on user's anime list.
+		/// </summary>
+		/// <param name="username">Username.</param>
+		/// <param name="searchQuery">Query to search.</param>
+		/// <returns>Entries on user's anime list.</returns>
+		public Task<UserAnimeList> GetUserAnimeListAsync(string username, string searchQuery)
+		{
+			var query = string.Concat("animelist", $"?q={searchQuery}");
+			var endpointParts = new[] { EndpointCategories.User, username, query };
+			return this.ExecuteGetRequestAsync<UserAnimeList>(endpointParts);
+		}
+
+		/// <summary>
+		/// Return manga with given MAL id.
+		/// </summary>
+		/// <param name="id">MAL id of manga.</param>
+		/// <returns>Manga with given MAL id.</returns>
+		public Task<Manga> GetMangaAsync(long id)
+		{
+			var endpointParts = new[] { EndpointCategories.Manga, id.ToString() };
+			return this.ExecuteGetRequestAsync<Manga>(endpointParts);
+		}
+
+		/// <summary>
+		/// Returns entries on user's manga list.
+		/// </summary>
+		/// <param name="username">Username.</param>
+		/// <param name="searchQuery">Query to search.</param>
+		/// <returns>Entries on user's manga list.</returns>
+		public Task<UserMangaList> GetUserMangaList(string username, string searchQuery)
+		{
+			var query = string.Concat("mangalist", $"?q={searchQuery}");
+			var endpointParts = new[] { EndpointCategories.User, username, query };
+			return this.ExecuteGetRequestAsync<UserMangaList>(endpointParts);
+		}
+	}
+}

--- a/PaperMalKing/Jikan/README.md
+++ b/PaperMalKing/Jikan/README.md
@@ -1,0 +1,1 @@
+﻿Uses a lot of code from [jikan.net](https://github.com/Ervie/jikan.net) library.

--- a/PaperMalKing/PaperMalKing.csproj
+++ b/PaperMalKing/PaperMalKing.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -11,7 +11,6 @@
     <PackageReference Include="CodeHollow.FeedReader" Version="1.2.1" />
     <PackageReference Include="DSharpPlus" Version="4.0.0-nightly-00656" />
     <PackageReference Include="DSharpPlus.CommandsNext" Version="4.0.0-nightly-00656" />
-    <PackageReference Include="JikanDotNet" Version="1.3.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Resolves #2. Copied a lot of code from [Jikan.Net](https://github.com/Ervie/jikan.net) but added inheritance for manga and anime, as bot uses same fields for them and there are no need for anime or manga specific properties.
Updated logic for publishing updates. Now they are publishing in chronological order no matter what type (anime or manga) update is.