### PR TITLE
Add rate-limiters

### DIFF
--- a/PaperMalKing/Data/BotConfig.cs
+++ b/PaperMalKing/Data/BotConfig.cs
@@ -18,6 +18,9 @@ namespace PaperMalKing.Data
 		/// </summary>
 		[JsonProperty("Database")]
 		public BotDatabaseConfig Database { get; private set; }
+
+		[JsonProperty("RateLimits")]
+		public BotRateLimitsConfig RateLimits { get; private set; } = new BotRateLimitsConfig();
 	}
 
 	/// <summary>
@@ -117,5 +120,43 @@ namespace PaperMalKing.Data
 		/// </summary>
 		[JsonProperty("ConnectionString")]
 		public string ConnectionString { get; private set; }
+	}
+
+	public sealed class BotRateLimitsConfig
+	{
+		public BotRateLimitsConfig()
+		{
+			this.JikanRateLimitConfig = new JikanRateLimitConfig()
+			{
+				RequestsCount = 1,
+				TimeConstraint = 2
+			};
+			this.MalRateLimitConfig = new MalRateLimitConfig()
+			{
+				RequestsCount = 1,
+				TimeConstraint = 2
+			};
+		}
+
+		[JsonProperty("JikanRateLimit")]
+		public JikanRateLimitConfig JikanRateLimitConfig { get; private set; }
+
+		[JsonProperty("MalRateLimit")]
+		public MalRateLimitConfig MalRateLimitConfig { get; private set; }
+	}
+
+	public sealed class JikanRateLimitConfig : BaseRateLimitConfig
+	{ }
+
+	public sealed class MalRateLimitConfig : BaseRateLimitConfig
+	{ }
+
+	public class BaseRateLimitConfig
+	{
+		[JsonProperty("RequestsCount")]
+		public int RequestsCount { get; set; }
+
+		[JsonProperty("TimeConstraintInSeconds")]
+		public int TimeConstraint { get; set; }
 	}
 }

--- a/PaperMalKing/Data/BotConfig.cs
+++ b/PaperMalKing/Data/BotConfig.cs
@@ -111,7 +111,7 @@ namespace PaperMalKing.Data
 	}
 
 	/// <summary>
-	/// Bot config options related to database 
+	/// Bot config options related to database
 	/// </summary>
 	public sealed class BotDatabaseConfig
 	{
@@ -122,6 +122,9 @@ namespace PaperMalKing.Data
 		public string ConnectionString { get; private set; }
 	}
 
+	/// <summary>
+	/// Bot config options related to MyAnimeList ratelimits
+	/// </summary>
 	public sealed class BotRateLimitsConfig
 	{
 		public BotRateLimitsConfig()
@@ -131,6 +134,10 @@ namespace PaperMalKing.Data
 				RequestsCount = 1,
 				TimeConstraint = 2
 			};
+			// Since there are no public API for MyAnimeList as well as documentation
+			// Default rate-limit will be 1 request every 2 seconds as it was advised to me in Jikan Discord Guild
+			// Source: https://discordapp.com/channels/460491088004907029/461199124205797439/676861111441686530
+			// I might change it later after Mal will get proper documentation
 			this.MalRateLimitConfig = new MalRateLimitConfig()
 			{
 				RequestsCount = 1,
@@ -138,24 +145,42 @@ namespace PaperMalKing.Data
 			};
 		}
 
+		/// <summary>
+		/// Bot rate limit config for Jikan
+		/// </summary>
 		[JsonProperty("JikanRateLimit")]
 		public JikanRateLimitConfig JikanRateLimitConfig { get; private set; }
 
+		/// <summary>
+		/// Bot rate limit config for MyAnimeList
+		/// </summary>
 		[JsonProperty("MalRateLimit")]
 		public MalRateLimitConfig MalRateLimitConfig { get; private set; }
 	}
 
+	/// <summary>
+	/// Bot rate limit config for Jikan
+	/// </summary>
 	public sealed class JikanRateLimitConfig : BaseRateLimitConfig
 	{ }
 
+	/// <summary>
+	/// Bot rate limit config for MyAnimeList
+	/// </summary>
 	public sealed class MalRateLimitConfig : BaseRateLimitConfig
 	{ }
 
 	public class BaseRateLimitConfig
 	{
+		/// <summary>
+		/// Amount of requests
+		/// </summary>
 		[JsonProperty("RequestsCount")]
 		public int RequestsCount { get; set; }
 
+		/// <summary>
+		/// Time in seconds after which amount of available requests will be reset
+		/// </summary>
 		[JsonProperty("TimeConstraintInSeconds")]
 		public int TimeConstraint { get; set; }
 	}

--- a/PaperMalKing/Data/BotConfig.cs
+++ b/PaperMalKing/Data/BotConfig.cs
@@ -132,7 +132,7 @@ namespace PaperMalKing.Data
 			this.JikanRateLimitConfig = new JikanRateLimitConfig()
 			{
 				RequestsCount = 1,
-				TimeConstraint = 2
+				TimeConstraint = 2000
 			};
 			// Since there are no public API for MyAnimeList as well as documentation
 			// Default rate-limit will be 1 request every 2 seconds as it was advised to me in Jikan Discord Guild
@@ -141,7 +141,7 @@ namespace PaperMalKing.Data
 			this.MalRateLimitConfig = new MalRateLimitConfig()
 			{
 				RequestsCount = 1,
-				TimeConstraint = 2
+				TimeConstraint = 2000
 			};
 		}
 
@@ -179,9 +179,9 @@ namespace PaperMalKing.Data
 		public int RequestsCount { get; set; }
 
 		/// <summary>
-		/// Time in seconds after which amount of available requests will be reset
+		/// Time in milliseconds after which amount of available requests will be reset
 		/// </summary>
-		[JsonProperty("TimeConstraintInSeconds")]
-		public int TimeConstraint { get; set; }
+		[JsonProperty("TimeConstraintInMilliseconds")]
+		public double TimeConstraint { get; set; }
 	}
 }

--- a/PaperMalKing/Data/FixedSizeQueue.cs
+++ b/PaperMalKing/Data/FixedSizeQueue.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+namespace PaperMalKing.Data
+{
+	public class FixedSizeQueue<T> : Queue<T>
+	{
+		public int Limit { get; set; }
+
+		public FixedSizeQueue(int limit)
+		{
+			this.Limit = limit;
+		}
+
+		public new void Enqueue(T item)
+		{
+			while (this.Limit >= this.Count)
+				this.Dequeue();
+
+			base.Enqueue(item);
+		}
+	}
+}

--- a/PaperMalKing/Data/FixedSizeQueue.cs
+++ b/PaperMalKing/Data/FixedSizeQueue.cs
@@ -1,22 +1,29 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 
 namespace PaperMalKing.Data
 {
-	public class FixedSizeQueue<T> : Queue<T>
+	public class FixedSizeQueue<T> : ConcurrentQueue<T>
 	{
+		private readonly object _lockObject;
 		public int Limit { get; set; }
 
 		public FixedSizeQueue(int limit)
 		{
 			this.Limit = limit;
+			this._lockObject = new object();
 		}
 
 		public new void Enqueue(T item)
 		{
-			while (this.Limit >= this.Count)
-				this.Dequeue();
-
 			base.Enqueue(item);
+			lock (this._lockObject)
+			{
+				while (this.Limit > base.Count)
+				{
+					base.TryDequeue(out _);
+				}
+			}
 		}
 	}
 }

--- a/PaperMalKing/Data/FixedSizeQueue.cs
+++ b/PaperMalKing/Data/FixedSizeQueue.cs
@@ -3,9 +3,20 @@ using System.Collections.Generic;
 
 namespace PaperMalKing.Data
 {
+	/// <summary>
+	/// Queue with fixed size
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
 	public class FixedSizeQueue<T> : ConcurrentQueue<T>
 	{
+		/// <summary>
+		/// Object for locking
+		/// </summary>
 		private readonly object _lockObject;
+
+		/// <summary>
+		/// Limit for amount of elements in queue
+		/// </summary>
 		public int Limit { get; set; }
 
 		public FixedSizeQueue(int limit)

--- a/PaperMalKing/Data/RateLimit.cs
+++ b/PaperMalKing/Data/RateLimit.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace PaperMalKing.Data
+{
+	public sealed class RateLimit
+	{
+		public readonly int AmountOfRequests;
+
+		public readonly TimeSpan TimeConstraint;
+
+		private readonly double _requestRestorationTime;
+
+		public RateLimit(int amountOfRequests, TimeSpan timeConstraint)
+		{
+			this.AmountOfRequests = amountOfRequests;
+			this.TimeConstraint = timeConstraint;
+			this._requestRestorationTime = this.TimeConstraint.TotalMilliseconds / (this.AmountOfRequests * 1.0);
+		}
+	}
+}

--- a/PaperMalKing/Data/RateLimiterToken.cs
+++ b/PaperMalKing/Data/RateLimiterToken.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace PaperMalKing.Data
+{
+	public struct RateLimiterToken
+	{
+		public readonly DateTime CreationDate;
+
+		public RateLimiterToken(DateTime creationDate)
+		{
+			this.CreationDate = creationDate;
+		}
+	}
+}

--- a/PaperMalKing/MyAnimeList/FeedReader/FeedReader.cs
+++ b/PaperMalKing/MyAnimeList/FeedReader/FeedReader.cs
@@ -29,7 +29,7 @@ namespace PaperMalKing.MyAnimeList.FeedReader
 			this.Log = log;
 			this._clock = clock;
 			this._rateLimiter =
-				new RateLimiter(new RateLimit(rlConfig.RequestsCount, TimeSpan.FromSeconds(rlConfig.TimeConstraint)),
+				new RateLimiter(new RateLimit(rlConfig.RequestsCount, TimeSpan.FromMilliseconds(rlConfig.TimeConstraint)),
 					this._clock, "MalRateLimiter", this.Log);
 			this._httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(45) };
 		}

--- a/PaperMalKing/MyAnimeList/FeedReader/FeedReader.cs
+++ b/PaperMalKing/MyAnimeList/FeedReader/FeedReader.cs
@@ -4,7 +4,9 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
 using DSharpPlus;
+using PaperMalKing.Data;
 using PaperMalKing.MyAnimeList.Exceptions;
+using PaperMalKing.Services;
 using PaperMalKing.Utilities;
 
 namespace PaperMalKing.MyAnimeList.FeedReader
@@ -14,33 +16,26 @@ namespace PaperMalKing.MyAnimeList.FeedReader
 	/// </summary>
 	public sealed class FeedReader
 	{
-		/// <summary>
-		/// Unix time milliseconds since last request to MyAnimeList
-		/// </summary>
-		private long _lastRequestDate;
-
 		private readonly LogDelegate Log;
+		private readonly ClockService _clock;
+		private readonly RateLimiter _rateLimiter;
 
 		private readonly HttpClient _httpClient;
 
 		private const string LogName = "MalFeedReader";
 
-		public FeedReader(LogDelegate log)
+		public FeedReader(LogDelegate log, ClockService clock, MalRateLimitConfig rlConfig)
 		{
 			this.Log = log;
+			this._clock = clock;
+			this._rateLimiter =
+				new RateLimiter(new RateLimit(rlConfig.RequestsCount, TimeSpan.FromSeconds(rlConfig.TimeConstraint)),
+					this._clock, "MalRateLimiter", this.Log);
 			this._httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(45) };
-			this._lastRequestDate = DateTimeOffset.Now.ToUnixTimeMilliseconds();
 		}
 
 		private async Task<HttpResponseMessage> MakeRequestAsync(string url)
 		{
-			var millisecondsPassed = DateTimeOffset.Now.ToUnixTimeMilliseconds() - this._lastRequestDate;
-			if (millisecondsPassed < 2000)
-			{
-				var delay = (int)(2000 - millisecondsPassed);
-				this.Log(LogLevel.Debug, LogName, $"Waiting {delay}ms before reading next rss feed.", DateTime.Now);
-				await Task.Delay(delay);
-			}
 
 			HttpResponseMessage response = null;
 			bool tryAgain;
@@ -49,17 +44,17 @@ namespace PaperMalKing.MyAnimeList.FeedReader
 				tryAgain = false;
 				try
 				{
+					await this._rateLimiter.GetTokenAsync();
+					// #if DEBUG
+					// this.Log(LogLevel.Debug, LogName, "Accessing MAL", this._clock.Now);
+					// #endif
 					response = await this._httpClient.GetAsync(url);
 					var statusCode = (int)response.StatusCode;
-					if (response.IsSuccessStatusCode)
-					{
-						this._lastRequestDate = DateTimeOffset.Now.ToUnixTimeMilliseconds();
-					}
-					else if (response.StatusCode == HttpStatusCode.TooManyRequests)
+					if (response.StatusCode == HttpStatusCode.TooManyRequests)
 					{
 						this.Log(LogLevel.Warning, LogName,
 							"Got ratelimited by Mal while trying to read rss feed, waiting 10s and retrying",
-							DateTime.Now);
+							this._clock.Now);
 						tryAgain = true;
 						response.Dispose();
 						await Task.Delay(TimeSpan.FromSeconds(10));

--- a/PaperMalKing/MyAnimeList/Jikan/JikanClient.cs
+++ b/PaperMalKing/MyAnimeList/Jikan/JikanClient.cs
@@ -37,7 +37,7 @@ namespace PaperMalKing.MyAnimeList.Jikan
 			this._suppressExceptions = true;
 			this._rateLimiter =
 				new JikanRateLimiter(
-					new RateLimit(rlConfig.RequestsCount, TimeSpan.FromSeconds(rlConfig.TimeConstraint)), this._clock,
+					new RateLimit(rlConfig.RequestsCount, TimeSpan.FromMilliseconds(rlConfig.TimeConstraint)), this._clock,
 					this.Log);
 			this._httpClient = HttpProvider.GetHttpClient(true);
 		}

--- a/PaperMalKing/MyAnimeList/Jikan/JikanClient.cs
+++ b/PaperMalKing/MyAnimeList/Jikan/JikanClient.cs
@@ -4,10 +4,12 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using DSharpPlus;
 using Newtonsoft.Json;
+using PaperMalKing.Data;
 using PaperMalKing.MyAnimeList.Exceptions;
 using PaperMalKing.MyAnimeList.Jikan.Data;
 using PaperMalKing.MyAnimeList.Jikan.Data.Models;
 using PaperMalKing.MyAnimeList.Jikan.Helpers;
+using PaperMalKing.Services;
 using PaperMalKing.Utilities;
 
 namespace PaperMalKing.MyAnimeList.Jikan
@@ -18,60 +20,26 @@ namespace PaperMalKing.MyAnimeList.Jikan
 
 		private readonly bool _suppressExceptions;
 
-		private long _lastRequestDate;
-
 		private readonly LogDelegate Log;
+		private readonly ClockService _clock;
+
+		private readonly JikanRateLimiter _rateLimiter;
 
 		private const string LogName = "JikanClient";
 
 		/// <summary>
 		/// Constructor.
 		/// </summary>
-		public JikanClient(LogDelegate logDelegate)
+		public JikanClient(LogDelegate logDelegate, ClockService clock, JikanRateLimitConfig rlConfig)
 		{
-			this._lastRequestDate = DateTimeOffset.Now.Subtract(TimeSpan.FromSeconds(10)).ToUnixTimeMilliseconds();
 			Log = logDelegate;
+			this._clock = clock;
 			this._suppressExceptions = true;
+			this._rateLimiter =
+				new JikanRateLimiter(
+					new RateLimit(rlConfig.RequestsCount, TimeSpan.FromSeconds(rlConfig.TimeConstraint)), this._clock,
+					this.Log);
 			this._httpClient = HttpProvider.GetHttpClient(true);
-		}
-
-		/// <summary>
-		/// Constructor.
-		/// </summary>
-		/// <param name="useHttps">Should client send SSL encrypted requests.</param>
-		/// <param name="suppressExceptions">Should exception be thrown in case of failed request. If true, failed request return null.</param>
-		public JikanClient(bool useHttps, LogDelegate logDelegate, bool suppressExceptions = true)
-		{
-			this._lastRequestDate = DateTimeOffset.Now.Subtract(TimeSpan.FromSeconds(10)).ToUnixTimeMilliseconds();
-			Log = logDelegate;
-			this._suppressExceptions = suppressExceptions;
-			this._httpClient = HttpProvider.GetHttpClient(useHttps);
-		}
-
-		/// <summary>
-		/// Constructor.
-		/// </summary>
-		/// <param name="endpointUrl">Endpoint of the REST API.</param>
-		/// <param name="suppressExceptions">Should exception be thrown in case of failed request. If true, failed request return null.</param>
-		public JikanClient(string endpointUrl, LogDelegate logDelegate, bool suppressExceptions = true)
-		{
-			this._lastRequestDate = DateTimeOffset.Now.Subtract(TimeSpan.FromSeconds(10)).ToUnixTimeMilliseconds();
-			Log = logDelegate;
-			this._suppressExceptions = suppressExceptions;
-			this._httpClient = HttpProvider.GetHttpClient(new Uri(endpointUrl));
-		}
-
-		/// <summary>
-		/// Constructor.
-		/// </summary>
-		/// <param name="endpointUrl">Endpoint of the REST API.</param>
-		/// <param name="suppressExceptions">Should exception be thrown in case of failed request. If true, failed request return null.</param>
-		public JikanClient(Uri endpointUrl, LogDelegate logDelegate, bool suppressExceptions = true)
-		{
-			this._lastRequestDate = DateTimeOffset.Now.Subtract(TimeSpan.FromSeconds(10)).ToUnixTimeMilliseconds();
-			Log = logDelegate;
-			this._suppressExceptions = suppressExceptions;
-			this._httpClient = HttpProvider.GetHttpClient(endpointUrl);
 		}
 
 		private async Task<T> ExecuteGetRequestAsync<T>(string[] args) where T : BaseJikanRequest
@@ -79,14 +47,6 @@ namespace PaperMalKing.MyAnimeList.Jikan
 			T returnedObject = null;
 			var requestUrl = string.Join("/", args);
 
-			var timePassed = DateTimeOffset.Now.ToUnixTimeMilliseconds() - this._lastRequestDate;
-			if (timePassed < 2000) //Delay between requests to Jikan should be 2 seconds
-			{
-				var delay = (int)(2000 - timePassed);
-				this.Log(LogLevel.Debug, LogName, $"Waiting for {delay} ms before next request to Jikan",
-					DateTime.Now);
-				await Task.Delay(delay);
-			}
 
 			bool tryAgain;
 			var url = this._httpClient.BaseAddress + requestUrl;
@@ -96,26 +56,28 @@ namespace PaperMalKing.MyAnimeList.Jikan
 				HttpResponseMessage response = null;
 				try
 				{
+					var token = await this._rateLimiter.GetTokenAsync();
 					response = await this._httpClient.GetAsync(requestUrl);
-					var statusCode = (int)response.StatusCode;
+					var statusCode = (int) response.StatusCode;
 					if (response.IsSuccessStatusCode)
 					{
 						string json = await response.Content.ReadAsStringAsync();
 
 						returnedObject = JsonConvert.DeserializeObject<T>(json);
-						if (!returnedObject.RequestCached)
-							this._lastRequestDate = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+						if (returnedObject.RequestCached)
+							await this._rateLimiter.PopulateTokenAsync(token);
 					}
 					else if (response.StatusCode == HttpStatusCode.TooManyRequests)
 					{
 						this.Log(LogLevel.Warning, LogName,
-							"Got ratelimited for Jikan, waiting 10 s and retrying request again", DateTime.Now);
+							"Got ratelimited for Jikan, waiting 10 s and retrying request again", this._clock.Now);
 						await Task.Delay(TimeSpan.FromSeconds(10));
 						tryAgain = true;
 					}
 					else if (statusCode >= 500 && statusCode < 600)
 					{
-						throw new ServerSideException(url, $"Encountered server-side issue while accessing '{url}' with status code '{statusCode}'");
+						throw new ServerSideException(url,
+							$"Encountered server-side issue while accessing '{url}' with status code '{statusCode}'");
 					}
 					else
 					{
@@ -137,7 +99,6 @@ namespace PaperMalKing.MyAnimeList.Jikan
 			} while (tryAgain);
 
 
-
 			return returnedObject;
 		}
 
@@ -148,7 +109,7 @@ namespace PaperMalKing.MyAnimeList.Jikan
 		/// <returns>Information about user's profile with given username.</returns>
 		public Task<UserProfile> GetUserProfileAsync(string username)
 		{
-			var endpointParts = new[] { EndpointCategories.User, username, "profile" };
+			var endpointParts = new[] {EndpointCategories.User, username, "profile"};
 
 			return this.ExecuteGetRequestAsync<UserProfile>(endpointParts);
 		}
@@ -160,7 +121,7 @@ namespace PaperMalKing.MyAnimeList.Jikan
 		/// <returns>Anime with given MAL id.</returns>
 		public Task<Anime> GetAnimeAsync(long id)
 		{
-			var endpointParts = new[] { EndpointCategories.Anime, id.ToString() };
+			var endpointParts = new[] {EndpointCategories.Anime, id.ToString()};
 			return this.ExecuteGetRequestAsync<Anime>(endpointParts);
 		}
 
@@ -173,7 +134,7 @@ namespace PaperMalKing.MyAnimeList.Jikan
 		public Task<UserAnimeList> GetUserAnimeListAsync(string username, string searchQuery)
 		{
 			var query = string.Concat("animelist", $"?q={searchQuery}");
-			var endpointParts = new[] { EndpointCategories.User, username, query };
+			var endpointParts = new[] {EndpointCategories.User, username, query};
 			return this.ExecuteGetRequestAsync<UserAnimeList>(endpointParts);
 		}
 
@@ -184,7 +145,7 @@ namespace PaperMalKing.MyAnimeList.Jikan
 		/// <returns>Manga with given MAL id.</returns>
 		public Task<Manga> GetMangaAsync(long id)
 		{
-			var endpointParts = new[] { EndpointCategories.Manga, id.ToString() };
+			var endpointParts = new[] {EndpointCategories.Manga, id.ToString()};
 			return this.ExecuteGetRequestAsync<Manga>(endpointParts);
 		}
 
@@ -198,7 +159,7 @@ namespace PaperMalKing.MyAnimeList.Jikan
 		{
 			searchQuery = WebUtility.UrlEncode(searchQuery);
 			var query = string.Concat("mangalist", $"?q={searchQuery}");
-			var endpointParts = new[] { EndpointCategories.User, username, query };
+			var endpointParts = new[] {EndpointCategories.User, username, query};
 			return this.ExecuteGetRequestAsync<UserMangaList>(endpointParts);
 		}
 	}

--- a/PaperMalKing/MyAnimeList/Jikan/JikanRateLimiter.cs
+++ b/PaperMalKing/MyAnimeList/Jikan/JikanRateLimiter.cs
@@ -1,0 +1,26 @@
+﻿using System.Threading.Tasks;
+using PaperMalKing.Data;
+using PaperMalKing.Services;
+
+namespace PaperMalKing.MyAnimeList.Jikan
+{
+	public class JikanRateLimiter : RateLimiter
+	{
+		/// <inheritdoc />
+		public JikanRateLimiter(RateLimit rateLimit, ClockService clock) : base(rateLimit, clock)
+		{ }
+
+		public async Task PopulateToken(RateLimiterToken token)
+		{
+			await this.SemaphoreSlim.WaitAsync();
+			try
+			{
+				this.Tokens.Enqueue(token);
+			}
+			finally
+			{
+				this.SemaphoreSlim.Release();
+			}
+		}
+	}
+}

--- a/PaperMalKing/MyAnimeList/Jikan/JikanRateLimiter.cs
+++ b/PaperMalKing/MyAnimeList/Jikan/JikanRateLimiter.cs
@@ -1,21 +1,25 @@
 ﻿using System.Threading.Tasks;
+using DSharpPlus;
 using PaperMalKing.Data;
 using PaperMalKing.Services;
+using PaperMalKing.Utilities;
 
 namespace PaperMalKing.MyAnimeList.Jikan
 {
 	public class JikanRateLimiter : RateLimiter
 	{
 		/// <inheritdoc />
-		public JikanRateLimiter(RateLimit rateLimit, ClockService clock) : base(rateLimit, clock)
+		public JikanRateLimiter(RateLimit rateLimit, ClockService clock, LogDelegate log) : base(rateLimit, clock,
+			"JknRateLimiter", log)
 		{ }
 
-		public async Task PopulateToken(RateLimiterToken token)
+		public async Task PopulateTokenAsync(RateLimiterToken token)
 		{
 			await this.SemaphoreSlim.WaitAsync();
 			try
 			{
 				this.Tokens.Enqueue(token);
+				this.Log(LogLevel.Debug, this.RateLimiterName, "Populating token", this.Clock.Now);
 			}
 			finally
 			{

--- a/PaperMalKing/Services/ClockService.cs
+++ b/PaperMalKing/Services/ClockService.cs
@@ -7,6 +7,9 @@ using System.Diagnostics;
 
 namespace PaperMalKing.Services
 {
+	/// <summary>
+	/// High precision clock
+	/// </summary>
 	public sealed class ClockService
 	{
 		private readonly long _maxIdleTime;

--- a/PaperMalKing/Services/ClockService.cs
+++ b/PaperMalKing/Services/ClockService.cs
@@ -1,0 +1,52 @@
+﻿/*
+https://www.nimaara.com/high-resolution-clock-in-net/
+*/
+
+using System;
+using System.Diagnostics;
+
+namespace PaperMalKing.Services
+{
+	public sealed class ClockService
+	{
+		private readonly long _maxIdleTime;
+		private const long TicksMultiplier = 1000 * TimeSpan.TicksPerMillisecond;
+
+		private DateTime _startTime;
+
+		private double _startTimestamp;
+
+		private readonly object _lockObject;
+
+		public ClockService()
+		{
+			this._maxIdleTime = TimeSpan.FromSeconds(10).Ticks;
+			this._startTime = DateTime.UtcNow;
+			this._startTimestamp = Stopwatch.GetTimestamp();
+			this._lockObject = new object();
+		}
+
+		public DateTime UtcNow
+		{
+			get
+			{
+				lock (this._lockObject)
+				{
+					double endTimestamp = Stopwatch.GetTimestamp();
+
+					var durationInTicks = (endTimestamp - this._startTimestamp) / Stopwatch.Frequency * TicksMultiplier;
+					if (durationInTicks >= this._maxIdleTime)
+					{
+						this._startTimestamp = Stopwatch.GetTimestamp();
+						this._startTime = DateTime.UtcNow;
+						return this._startTime;
+					}
+
+					return this._startTime.AddTicks((long) durationInTicks);
+				}
+			}
+		}
+
+		public DateTime Now => this.UtcNow.ToLocalTime();
+	}
+}

--- a/PaperMalKing/Services/RateLimiter.cs
+++ b/PaperMalKing/Services/RateLimiter.cs
@@ -45,8 +45,9 @@ namespace PaperMalKing.Services
 				if (isTooEarlyToRefill && !areTokensAvailable)
 				{
 					var delay = (nextRefillDateTime - now).Duration();
+					var delayInMs = Convert.ToInt32(delay.TotalMilliseconds);
 					this.Log(LogLevel.Debug, this.RateLimiterName,
-						$"Waiting {delay.TotalMilliseconds:F1}ms before getting next token.", this.Clock.Now);
+						$"Waiting {delayInMs}ms before getting next token.", this.Clock.Now);
 					await Task.Delay(delay);
 				}
 				else if (isTooEarlyToRefill) // && TokensAreAvailable

--- a/PaperMalKing/Services/RateLimiter.cs
+++ b/PaperMalKing/Services/RateLimiter.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using PaperMalKing.Data;
+
+namespace PaperMalKing.Services
+{
+	public class RateLimiter
+	{
+		public readonly RateLimit RateLimit;
+		private readonly ClockService _clock;
+
+		private DateTime _lastUpdateTime;
+
+		protected readonly FixedSizeQueue<RateLimiterToken> Tokens;
+
+		protected readonly SemaphoreSlim SemaphoreSlim;
+
+		public RateLimiter(RateLimit rateLimit, ClockService clock)
+		{
+			this.RateLimit = rateLimit;
+			this._clock = clock;
+			this.SemaphoreSlim = new SemaphoreSlim(1, 1);
+			this.Tokens = new FixedSizeQueue<RateLimiterToken>(this.RateLimit.AmountOfRequests);
+		}
+
+		public async Task<RateLimiterToken> GetTokenAsync()
+		{
+			await this.SemaphoreSlim.WaitAsync();
+			try
+			{
+				var nextRefillDateTime = this._lastUpdateTime.Add(this.RateLimit.TimeConstraint);
+				var now = this._clock.UtcNow;
+				var areTokensAvailable = this.Tokens.Any();
+				var isTooEarlyToRefill = DateTime.Compare(now, nextRefillDateTime) < 0;
+				if (isTooEarlyToRefill && !areTokensAvailable)
+				{
+					var delay = (nextRefillDateTime - now).Duration();
+					await Task.Delay(delay);
+				}
+				else if (isTooEarlyToRefill) // && TokensAreAvailable
+				{
+					return this.Tokens.Dequeue();
+				}
+				else // Removing old tokens to generate new
+				{
+					this.Tokens.Clear();
+				}
+
+				this._lastUpdateTime = this._clock.UtcNow;
+				for (int i = 0; i < this.RateLimit.AmountOfRequests - 1; i++)
+					this.Tokens.Enqueue(new RateLimiterToken(this._clock.UtcNow));
+				return new RateLimiterToken(this._clock.UtcNow);
+			}
+			finally
+			{
+				this.SemaphoreSlim.Release();
+			}
+		}
+	}
+}

--- a/PaperMalKing/config.example.json
+++ b/PaperMalKing/config.example.json
@@ -20,11 +20,11 @@
   "RateLimits": {
     "JikanRateLimit": {
       "RequestsCount": 1,
-      "TimeConstraintInSeconds": 2
+      "TimeConstraintInMilliseconds": 2000
     },
     "MalRateLimit": {
       "RequestsCount": 1,
-      "TimeConstraintInSeconds": 2
+      "TimeConstraintInMilliseconds": 2000
     }
   },
   "Database": {

--- a/PaperMalKing/config.example.json
+++ b/PaperMalKing/config.example.json
@@ -17,6 +17,16 @@
       "DmHelp": false
     }
   },
+  "RateLimits": {
+    "JikanRateLimit": {
+      "RequestsCount": 1,
+      "TimeConstraintInSeconds": 2
+    },
+    "MalRateLimit": {
+      "RequestsCount": 1,
+      "TimeConstraintInSeconds": 2
+    }
+  },
   "Database": {
     "ConnectionString": "Data Source=path-to-your-database.db"
   }


### PR DESCRIPTION
Adds proper rate-limiters to MalRssReader and Jikan REST API wrapper.
[Jikan REST API docs on rate-limiting.](https://jikan.docs.apiary.io/introduction/information/rate-limiting)
Notice [new fields](https://github.com/N0D4N/PaperMalKing/blob/8d0744bda65a2224637d946254c9f8aaa99d9b0b/PaperMalKing/config.example.json#L20-L29) in bot config. They are optional and are filled with [default values](https://github.com/N0D4N/PaperMalKing/blob/8d0744bda65a2224637d946254c9f8aaa99d9b0b/PaperMalKing/Data/BotConfig.cs#L130-L146) so if you add this to your config file bot won't break and will be working with default rate-limits, however if JIkan lowers rate-limits you will need to fill them to your config.