### PR TITLE
Shuffle user's before checking their feeds

### DIFF
--- a/PaperMalKing/Services/MalService.cs
+++ b/PaperMalKing/Services/MalService.cs
@@ -19,6 +19,7 @@ using PaperMalKing.MyAnimeList.Exceptions;
 using PaperMalKing.MyAnimeList.FeedReader;
 using PaperMalKing.MyAnimeList.Jikan;
 using PaperMalKing.MyAnimeList.Jikan.Data.Interfaces;
+using PaperMalKing.Utilities;
 
 namespace PaperMalKing.Services
 {
@@ -498,12 +499,10 @@ namespace PaperMalKing.Services
 			this.Updating = true;
 			this._discordClient.DebugLogger.LogMessage(LogLevel.Info, LogName, "Starting checking for updates",
 				this._clock.Now);
-			PmkUser[] users;
 			using var db = new DatabaseContext(this._config);
 			try
 			{
-				users = db.Users.Include(ug => ug.Guilds).ThenInclude(g => g.Guild).ToArray();
-
+				var users = db.Users.Include(ug => ug.Guilds).ThenInclude(g => g.Guild).ToArray().Shuffle();
 				foreach (var user in users)
 				{
 					this._discordClient.DebugLogger.LogMessage(LogLevel.Info, LogName,

--- a/PaperMalKing/Utilities/Extensions.cs
+++ b/PaperMalKing/Utilities/Extensions.cs
@@ -1,4 +1,7 @@
-﻿using DSharpPlus;
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using DSharpPlus;
 
 namespace PaperMalKing.Utilities
 {
@@ -26,6 +29,27 @@ namespace PaperMalKing.Utilities
 				LogLevel.Critical => "CRT",
 				_ => "UNK"
 			};
+		}
+		
+		public static IList<T> Shuffle<T>(this IList<T> list)
+		{
+			using(var provider = new RNGCryptoServiceProvider())
+			{
+				int n = list.Count;
+				while(n > 1)
+				{
+					byte[] box = new byte[sizeof(int)];
+					provider.GetBytes(box);
+					int bit = BitConverter.ToInt32(box, 0);
+					int k = Math.Abs(bit) % n;
+					n--;
+					T value = list[k];
+					list[k] = list[n];
+					list[n] = value;
+				}
+			}
+
+			return list;
 		}
 	}
 }


### PR DESCRIPTION
Shuffle user's before cheking their feeds. This will bring some variety and also fix issue when the only the same part of user's feeds are available to read due MAL issues.