### PR TITLE
Fix getting the user's avatar from MAL

### DIFF
--- a/PaperMalKing/Data/Models.cs
+++ b/PaperMalKing/Data/Models.cs
@@ -46,12 +46,21 @@ namespace PaperMalKing.Data
 		{
 			get
 			{
-				if (this.MalId.HasValue)
-					return $"https://cdn.myanimelist.net/images/userimages/{this.MalId.Value}.jpg";
-				else
-					return null;
+				if (this._malAvatarUrl == null)
+				{
+					if (this.MalId.HasValue)
+					{
+						var ts = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+						this._malAvatarUrl = $"https://cdn.myanimelist.net/images/userimages/{this.MalId.Value}.jpg?t={ts}";
+					}
+				}
+
+				return this._malAvatarUrl;
 			}
 		}
+
+		[NotMapped]
+		private string _malAvatarUrl;
 
 		/// <summary>
 		/// Url to user profile on MAL


### PR DESCRIPTION
Fixes an issue when in Discord's embeds MAL user's avatar was outdated.
I guess it happens because URL to user's avatar on MAL was constant and looked like
`https://cdn.myanimelist.net/images/userimages/{user's id on MAL}.jpg` and Discord cached it on its server's. Now link is constant withing 1 check for updates and looks like `https://cdn.myanimelist.net/images/userimages/{user's id on MAL}.jpg?t={unix timestamp in seconds}`, so Discord won't cache user's avatars.
Also it should slightly reduce amount of memory allocation when user have more than 1 update.